### PR TITLE
Support setting DnD in status & allow 'until' time parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Example configuration:
                     key: 7
                     text: Off sick
                     emoji: ':face_with_thermometer:'
+                    until: tomorrow at 8am
                   - action: status
                     key: 8
                     text: On holiday
@@ -71,7 +72,7 @@ This plugin requires a Slack API key to function.
 
 Head over to https://api.slack.com/apps to create your app.
 
-Once you have created your app you will be able to access your OAuth Access Token under **OAuth & Permissions** - this 
+Once you have created your app you will be able to access your OAuth Access Token under **OAuth & Permissions** - this
 is your `api_key` value.
 
 ### Scopes

--- a/devdeck_slack/slack_deck.py
+++ b/devdeck_slack/slack_deck.py
@@ -63,9 +63,20 @@ class SlackDeck(DeckController):
                             'type': 'string',
                             'required': False
                         },
+                        'dnd': {
+                            'type': 'boolean',
+                            'required': False
+                        },
                         'duration': {
                             'type': 'integer',
-                            'required': False
+                            'min': 1,
+                            'required': False,
+                            'excludes': 'until',
+                        },
+                        'until': {
+                            'type': 'string',
+                            'required': False,
+                            'excludes': 'duration'
                         }
                     }
                 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ assertpy
 devdeck-core==1.0.6
 pytest
 slack_sdk==3.1.0
+dateparser

--- a/tests/devdeck_slack/test_slack_status_control.py
+++ b/tests/devdeck_slack/test_slack_status_control.py
@@ -1,4 +1,8 @@
+import math
 from unittest import mock
+import time
+
+import dateparser
 
 from devdeck_core.mock_deck_context import mock_context, assert_rendered
 from devdeck_core.renderer import Renderer
@@ -21,5 +25,53 @@ class TestSlackStatusControl:
             control.pressed()
             api_client.users_profile_set.assert_called_with(profile={
                 'status_text': 'On lunch',
-                'status_emoji': ':sandwich:'
+                'status_emoji': ':sandwich:',
+                'status_expiration': 0
             })
+            api_client.dnd_setSnooze.assert_not_called()
+
+    @mock.patch('slack_sdk.WebClient')
+    def test_dnd_set_without_timeout(self, api_client):
+        control = SlackStatusControl(0, api_client, **{
+            'emoji': ':calendar:', 'text': 'Busy', 'dnd': True
+        })
+        with mock_context(control) as ctx:
+            control.pressed()
+            api_client.users_profile_set.assert_called_with(profile={
+                'status_text': 'Busy',
+                'status_emoji': ':calendar:',
+                'status_expiration': 0
+            })
+            api_client.dnd_setSnooze.assert_called_with()
+
+    @mock.patch('slack_sdk.WebClient')
+    def test_dnd_set_with_duration(self, api_client):
+        control = SlackStatusControl(0, api_client, **{
+            'emoji': ':calendar:', 'text': 'Busy', 'dnd': True, 'duration': 5
+        })
+        with mock_context(control) as ctx:
+            control.pressed()
+            api_client.users_profile_set.assert_called_with(profile={
+                'status_text': 'Busy',
+                'status_emoji': ':calendar:',
+                'status_expiration': int(time.time()) + 300
+            })
+            api_client.dnd_setSnooze.assert_called_with(num_minutes=5)
+
+    @mock.patch('slack_sdk.WebClient')
+    def test_dnd_set_with_until(self, api_client):
+        control = SlackStatusControl(0, api_client, **{
+            'emoji': ':calendar:', 'text': 'Busy', 'dnd': True,
+            'until': 'tomorrow at 7am'
+        })
+        ts = dateparser.parse('tomorrow at 7am',
+                              settings={'RETURN_AS_TIMEZONE_AWARE': True})
+        minutes = int(math.ceil((ts.timestamp() - time.time()) / 60))
+        with mock_context(control) as ctx:
+            control.pressed()
+            api_client.users_profile_set.assert_called_with(profile={
+                'status_text': 'Busy',
+                'status_emoji': ':calendar:',
+                'status_expiration': int(ts.timestamp())
+            })
+            api_client.dnd_setSnooze.assert_called_with(num_minutes=minutes)


### PR DESCRIPTION
Tries to mirror the convenience of setting both options, as was recently added to the Slack client.