### PR TITLE
Several minor enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Example configuration:
                     key: 7
                     text: Off sick
                     emoji: ':face_with_thermometer:'
+                    until: tomorrow at 8am
                   - action: status
                     key: 8
                     text: On holiday
@@ -71,7 +72,7 @@ This plugin requires a Slack API key to function.
 
 Head over to https://api.slack.com/apps to create your app.
 
-Once you have created your app you will be able to access your OAuth Access Token under **OAuth & Permissions** - this 
+Once you have created your app you will be able to access your OAuth Access Token under **OAuth & Permissions** - this
 is your `api_key` value.
 
 ### Scopes

--- a/devdeck_slack/slack_deck.py
+++ b/devdeck_slack/slack_deck.py
@@ -63,6 +63,10 @@ class SlackDeck(DeckController):
                             'type': 'string',
                             'required': False
                         },
+                        'emoji_slack': {
+                            'type': 'string',
+                            'required': False
+                        },
                         'dnd': {
                             'type': 'boolean',
                             'required': False

--- a/devdeck_slack/slack_deck.py
+++ b/devdeck_slack/slack_deck.py
@@ -63,9 +63,20 @@ class SlackDeck(DeckController):
                             'type': 'string',
                             'required': False
                         },
+                        'dnd': {
+                            'type': 'boolean',
+                            'required': False
+                        },
                         'duration': {
                             'type': 'integer',
-                            'required': False
+                            'min': 1,
+                            'required': False,
+                            'excludes': 'until',
+                        },
+                        'until': {
+                            'type': 'string',
+                            'required': False,
+                            'excludes': 'duration'
                         }
                     }
                 }

--- a/devdeck_slack/slack_status_control.py
+++ b/devdeck_slack/slack_status_control.py
@@ -34,7 +34,8 @@ class SlackStatusControl(DeckControl):
         dnd = self.settings.get('dnd', False)
         self.api_client.users_profile_set(profile={
             "status_text": self.settings['text'],
-            "status_emoji": self.settings['emoji'],
+            "status_emoji": self.settings.get('emoji_slack',
+                                              self.settings['emoji']),
             "status_expiration": expires
         })
         if dnd:
@@ -53,6 +54,10 @@ class SlackStatusControl(DeckControl):
             'emoji': {
                 'type': 'string',
                 'required': True,
+            },
+            'emoji_slack': {
+                'type': 'string',
+                'required': False
             },
             'dnd': {
                 'type': 'boolean',

--- a/devdeck_slack/slack_status_control.py
+++ b/devdeck_slack/slack_status_control.py
@@ -2,7 +2,8 @@ import logging
 import math
 import time
 
-import dateparser
+import parsedatetime
+import tzlocal
 
 from devdeck_core.controls.deck_control import DeckControl
 
@@ -11,6 +12,8 @@ class SlackStatusControl(DeckControl):
     def __init__(self, key_no, api_client, **kwargs):
         self.api_client = api_client
         self.__logger = logging.getLogger('devdeck')
+        self.cal = parsedatetime.Calendar(
+            version=parsedatetime.VERSION_CONTEXT_STYLE)
         super().__init__(key_no, **kwargs)
 
     def initialize(self):
@@ -24,8 +27,8 @@ class SlackStatusControl(DeckControl):
         if 'duration' in self.settings:
             expires = int(time.time()) + self.settings['duration'] * 60
         elif 'until' in self.settings:
-            dt = dateparser.parse(self.settings['until'],
-                                  settings={'RETURN_AS_TIMEZONE_AWARE': True})
+            dt, _ = self.cal.parseDT(self.settings['until'],
+                                     tzinfo=tzlocal.get_localzone())
             if dt is None:
                 self.__logger.error("Could not parse until: %s",
                                     self.settings['until'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ assertpy
 devdeck-core==1.0.6
 pytest
 slack_sdk==3.1.0
-dateparser
+parsedatetime
+tzlocal

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ assertpy
 devdeck-core==1.0.6
 pytest
 slack_sdk==3.1.0
+dateparser

--- a/tests/devdeck_slack/test_slack_status_control.py
+++ b/tests/devdeck_slack/test_slack_status_control.py
@@ -1,4 +1,8 @@
+import math
 from unittest import mock
+import time
+
+import dateparser
 
 from devdeck_core.mock_deck_context import mock_context, assert_rendered
 from devdeck_core.renderer import Renderer
@@ -21,5 +25,53 @@ class TestSlackStatusControl:
             control.pressed()
             api_client.users_profile_set.assert_called_with(profile={
                 'status_text': 'On lunch',
-                'status_emoji': ':sandwich:'
+                'status_emoji': ':sandwich:',
+                'status_expiration': 0
             })
+            api_client.dnd_setSnooze.assert_not_called()
+
+    @mock.patch('slack_sdk.WebClient')
+    def test_dnd_set_without_timeout(self, api_client):
+        control = SlackStatusControl(0, api_client, **{
+            'emoji': ':calendar:', 'text': 'Busy', 'dnd': True
+        })
+        with mock_context(control) as ctx:
+            control.pressed()
+            api_client.users_profile_set.assert_called_with(profile={
+                'status_text': 'Busy',
+                'status_emoji': ':calendar:',
+                'status_expiration': 0
+            })
+            api_client.dnd_setSnooze.assert_called_with()
+
+    @mock.patch('slack_sdk.WebClient')
+    def test_dnd_set_with_duration(self, api_client):
+        control = SlackStatusControl(0, api_client, **{
+            'emoji': ':calendar:', 'text': 'Busy', 'dnd': True, 'duration': 5
+        })
+        with mock_context(control) as ctx:
+            control.pressed()
+            api_client.users_profile_set.assert_called_with(profile={
+                'status_text': 'Busy',
+                'status_emoji': ':calendar:',
+                'status_expiration': int(time.time()) + 300
+            })
+            api_client.dnd_setSnooze.assert_called_with(num_minutes=5)
+
+    @mock.patch('slack_sdk.WebClient')
+    def test_dnd_set_with_until(self, api_client):
+        control = SlackStatusControl(0, api_client, **{
+            'emoji': ':calendar:', 'text': 'Busy', 'dnd': True,
+            'until': 'tomorrow at 7am'
+        })
+        ts = dateparser.parse('tomorrow at 7am',
+                              settings={'RETURN_AS_TIMEZONE_AWARE': True})
+        minutes = int(math.ceil((ts.timestamp() - time.time()) / 60))
+        with mock_context(control) as ctx:
+            control.pressed()
+            api_client.users_profile_set.assert_called_with(profile={
+                'status_text': 'Busy',
+                'status_emoji': ':calendar:',
+                'status_expiration': int(ts.timestamp())
+            })
+            api_client.dnd_setSnooze.assert_called_with(num_minutes=minutes)

--- a/tests/devdeck_slack/test_slack_status_control.py
+++ b/tests/devdeck_slack/test_slack_status_control.py
@@ -31,6 +31,20 @@ class TestSlackStatusControl:
             api_client.dnd_setSnooze.assert_not_called()
 
     @mock.patch('slack_sdk.WebClient')
+    def test_pressed_sets_status_alt_emoji(self, api_client):
+        control = SlackStatusControl(0, api_client, **{
+            'emoji': ':sandwich:', 'text': 'On lunch', 'emoji_slack': ':test:'
+        })
+        with mock_context(control) as ctx:
+            control.pressed()
+            api_client.users_profile_set.assert_called_with(profile={
+                'status_text': 'On lunch',
+                'status_emoji': ':test:',
+                'status_expiration': 0
+            })
+            api_client.dnd_setSnooze.assert_not_called()
+
+    @mock.patch('slack_sdk.WebClient')
     def test_dnd_set_without_timeout(self, api_client):
         control = SlackStatusControl(0, api_client, **{
             'emoji': ':calendar:', 'text': 'Busy', 'dnd': True

--- a/tests/devdeck_slack/test_slack_status_control.py
+++ b/tests/devdeck_slack/test_slack_status_control.py
@@ -2,7 +2,8 @@ import math
 from unittest import mock
 import time
 
-import dateparser
+import parsedatetime
+import tzlocal
 
 from devdeck_core.mock_deck_context import mock_context, assert_rendered
 from devdeck_core.renderer import Renderer
@@ -78,8 +79,8 @@ class TestSlackStatusControl:
             'emoji': ':calendar:', 'text': 'Busy', 'dnd': True,
             'until': 'tomorrow at 7am'
         })
-        ts = dateparser.parse('tomorrow at 7am',
-                              settings={'RETURN_AS_TIMEZONE_AWARE': True})
+        c = parsedatetime.Calendar(version=parsedatetime.VERSION_CONTEXT_STYLE)
+        ts, _ = c.parseDT('tomorrow at 7am', tzinfo=tzlocal.get_localzone())
         minutes = int(math.ceil((ts.timestamp() - time.time()) / 60))
         with mock_context(control) as ctx:
             control.pressed()


### PR DESCRIPTION
1. Allow optional separate emoji for Slack status from the one rendered on Stream Deck
2. Alternate field to duration that can specify relative dates such as "monday at 7:30am"
3. Set DnD and status at same time, with same expiration (similar to recent Slack UI functionality)